### PR TITLE
upgrade to postcss v4 + changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# HEAD
+
+- Added: upgrade to postcss v4.x
+
+# 0.1.5 - 2014-12-
+
+- Fixed: npm "No repository field" warning
+
+# 0.1.4 - 2014-
+
+- Added: color functions support for drop-shadow filter. Now support rgb, rgba, hsl and hsla ([#3](https://github.com/iamvdo/pleeease-filters/issues/3))
+- Added: upgrade to postcss v3.x
+
+# 0.1.3 - 2014
+
+- Fixed: charset issue
+
+# 0.1.2 - 2014
+
+- Added: Create SVG blur filter, even with unit-less 0
+
+# 0.1.1 - 2014
+
+- Changed: Don't add filters if they're already presents
+
+# 0.1.0 - 2014
+
+✨ Initial release

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test": "jasmine-node spec"
   },
   "dependencies": {
-    "postcss": "^3.0.0",
+    "postcss": "^4.0.2",
     "onecolor": "~2.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
After that, maybe we should think to make a plugin without postcss dep (like most of postcss plugin)?
Meanwhile we can release that as 0.2 or 1.0.0. As you want.

Please [keep a changelog](http://keepachangelog.com/) up to date ;)