### PR TITLE
Create a plugin with a standard API

### DIFF
--- a/index.js
+++ b/index.js
@@ -643,11 +643,6 @@ Filter.prototype.process = function (css) {
 	return postcss().use(this.postcss).process(css).css;
 };
 
-var filter = function (options) {
-	return new Filter(options);
-};
-filter.process = function (css, options) {
-	return new Filter(options).process(css);
-};
-
-module.exports = filter;
+module.exports = postcss.plugin('pleeease-filters', function(options) {
+	return new Filter(options).postcss;
+});

--- a/spec/filters-spec.js
+++ b/spec/filters-spec.js
@@ -22,7 +22,7 @@ var test = function (name, options) {
   // process
   var processed = filter.process(css, options);
 
-  expect(processed).toBe(expected);
+  expect(processed.css).toBe(expected);
 };
 
 describe('pleeease-filters', function () {


### PR DESCRIPTION
Expose a plugin create with PostCSS standard API. Current version of pleeease-filters may cause error with some other PostCSS toolchain (e.g. [postcss-devtools](https://github.com/postcss/postcss-devtools)).